### PR TITLE
Fixed issue with RepeatingFieldSet passing event args to the add() method

### DIFF
--- a/lib/RepeatingFieldSet.js
+++ b/lib/RepeatingFieldSet.js
@@ -55,10 +55,14 @@ var RepeatingFieldset = React.createClass({
         {fields}
         <button
           type="button"
-          onClick={this.add}
+          onClick={this.onAdd}
           className="react-forms-repeating-fieldset-add">Add</button>
       </div>
     );
+  },
+
+  onAdd: function () {
+    this.add();
   }
 
 });


### PR DESCRIPTION
When the `add()` method of `RepeatingFieldSetMixin` was updated to accept a value to add, it broke the `RepeatingFieldSet` component, since the `onClick` was sending the event args to `add()`, who would then try to store the event args in the form value.
