### PR TITLE
Add React to package.js to prevent errors on .

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "main": "index.js",
   "dependencies": {
+    "react": "^0.10.0",
     "less-file": "0.0.8",
     "node-jsx": "^0.10.0",
     "react-tools": "^0.10.0",


### PR DESCRIPTION
Need to add React to package.json in order to prevent errors when running `make preview`:

``` bash

➜  docs git:(master) make preview
  starting preview server
  using config file: .../react-forms/docs/config.json

  error Error loading plugin './plugins/react-templates.coffee': Cannot find module 'react'
```
