### PR TITLE
Allows nodes in schemas to be null

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ The primary authors of are
 
 This software includes contributions made by many individuals:
 
+    Andrew Ingram
     Jason Simeone
 
 For exact contribution history, see the revision log available at

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -29,11 +29,13 @@ class SchemaNode extends Node {
 
     if (args.length !== 0) {
       forEachNested(args, (arg) => {
-        utils.invariant(
-          arg.name,
-          'props fields should specify name property'
-        );
-        children[arg.name] = arg;
+        if (arg) {
+          utils.invariant(
+              arg.name,
+              'props fields should specify name property'
+          );
+          children[arg.name] = arg;
+        }
       });
     }
 

--- a/tests/dynamic-schema.js
+++ b/tests/dynamic-schema.js
@@ -67,4 +67,26 @@ describe('form with dynamic schema', function() {
 
   });
 
+  it('allow conditional nodes', function() {
+
+    function getSchema(city) {
+      return (
+        <Schema>
+          <Property name="address_1" required />
+          {city === 'OTHER' ? <Property name="city" required /> : null}
+        </Schema>
+      );
+    }
+
+    assert.doesNotThrow(function() {
+      var schema = getSchema('LON');
+      assert.equal(Object.keys(schema.children).length, 1);
+    });
+
+    assert.doesNotThrow(function() {
+      var schema = getSchema('OTHER');
+      assert.equal(Object.keys(schema.children).length, 2);
+    });
+  });
+
 });


### PR DESCRIPTION
Makes it possible for ternary operators with null results to be used when building a schema. Fixes #28
