### PR TITLE
Add `.rf-Field--dirty` className when field value is not undefined

### DIFF
--- a/lib/Field.js
+++ b/lib/Field.js
@@ -32,7 +32,8 @@ var Field = React.createClass({
 
     var className = cx({
       'rf-Field': true,
-      'rf-Field--invalid': isInvalid
+      'rf-Field--invalid': isInvalid,
+      'rf-Field--dirty': !value.isUndefined
     });
 
     var id = this._rootNodeID;

--- a/lib/__tests__/Field-test.js
+++ b/lib/__tests__/Field-test.js
@@ -195,6 +195,25 @@ describe('forms', () => {
         }));
         assertMessages(form, ['externalValidation.failure', 'validation.failure']);
       });
+
+      it('renders a dirty className if value is valid or invalid and dirtied', () => {
+        var validForm = ReactTestUtils.renderIntoDocument(Form({
+          field: Field(),
+          value: 'some'
+        }));
+
+        var validDirtied = ReactTestUtils.scryRenderedDOMComponentsWithClass(validForm, 'rf-Field--dirty');
+        assert.strictEqual(validDirtied.length, 1);
+
+        var form = ReactTestUtils.renderIntoDocument(Form({
+          field: Field(),
+          value: 'some',
+          schema: schema.Property({validate: (value) => false})
+        }));
+
+        var dirtied = ReactTestUtils.scryRenderedDOMComponentsWithClass(form, 'rf-Field--dirty');
+        assert.strictEqual(dirtied.length, 1);
+      });
     });
 
     describe('hint rendering', () => {


### PR DESCRIPTION
This makes for better UX when styling e.g.

``` css
.rf-Field--invalid.rf-Field--dirty {
  border: red;
}
```

That lets me target invalid fields that have been `dirtied`. This would fix #30
