### PR TITLE
harmony transformers treat `_method` as private

### DIFF
--- a/lib/Value.js
+++ b/lib/Value.js
@@ -90,10 +90,10 @@ class Value {
 
   update(update) {
     var current = this;
-    update = this._updateSelf(update);
+    update = this.updateSelf(update);
 
     while (current.parent) {
-      update = current.parent._updateChild(current.name, update);
+      update = current.parent.updateChild(current.name, update);
       current = current.parent;
     }
 
@@ -105,7 +105,7 @@ class Value {
     ));
   }
 
-  _updateSelf(update) {
+  updateSelf(update) {
     u.invariant(
       !(update.value === undefined
         && update.serialized === undefined
@@ -171,8 +171,8 @@ function mergeValidation(a, b) {
 
 class SchemaValue extends Value {
 
-  _updateChild(name, update) {
-    update = this._updateSelf(update);
+  updateChild(name, update) {
+    update = this.updateSelf(update);
 
     var value = {};
     var serialized = {};
@@ -207,8 +207,8 @@ class SchemaValue extends Value {
 
 class ListValue extends Value {
 
-  _updateChild(name, update) {
-    update = this._updateSelf(update);
+  updateChild(name, update) {
+    update = this.updateSelf(update);
 
     var value = this.value.slice(0);
     var serialized = this.serialized.slice(0);


### PR DESCRIPTION
required to use with latest `jsx-loader`