### PR TITLE
better dynamic schema handling

### DIFF
--- a/lib/Value.js
+++ b/lib/Value.js
@@ -129,7 +129,7 @@ class Value {
       'Access to key "%s" which does not exist in schema', key
     );
     var value = this.value.get(key, defaultValue(abstractNode));
-    var {node, value} = abstractNode.instantiate(value);
+    var {node, value} = abstractNode.instantiate(value, undefined);
     var externalValidation = this.externalValidation.has(key) ?
       this.externalValidation.get(key) :
       ValidationResult.success();
@@ -174,7 +174,7 @@ class Value {
 
   set(value) {
     value = fromJS(value);
-    var {node, value} = this.abstractNode.instantiate(value);
+    var {node, value} = this.abstractNode.instantiate(value, this.node);
     var attributes = {
       node, value,
       // either get a new serialized value for scalar nodes or destroy it
@@ -211,7 +211,7 @@ class Value {
   }
 
   setSchema(abstractNode) {
-    var {node, value} = abstractNode.instantiate(this.value);
+    var {node, value} = abstractNode.instantiate(this.value, this.node);
     return this.__update({value, node, abstractNode});
   }
 
@@ -247,16 +247,18 @@ class Value {
 
   __onUpdate(child) {
     var value = this.value.set(child.key, child.value);
-    var {node, value} = this.abstractNode.instantiate(value);
+    var {node, value, dirty} = this.abstractNode.instantiate(value, this.node);
     if (node.constructor !== this.node.constructor) {
       value = defaultValue(node);
-      return this.__with({node, value, serialized: EMPTY_MAP}).__grow();
+      return this.__with({node, value, serialized: EMPTY_MAP, dirty: (dirty || EMPTY_MAP)}).__grow();
+    } else if (!is(node, this.node)) {
+      return this.__with({node, value, serialized: EMPTY_MAP, dirty: (dirty || EMPTY_MAP)}).__grow();
     } else {
       var childrenValidation = child.validation.isSuccess ?
         ValidationResult.children(this.validation.children.remove(child.key)) :
         ValidationResult.children(this.validation.children.set(child.key, child.validation));
       var validation = validate(node, value, childrenValidation);
-      var dirty = child.dirty.size > 0 ? this.dirty.set(child.key, child.dirty) : this.dirty.remove(child.key);
+      dirty = dirty ? dirty : (child.dirty.size > 0 ? this.dirty.set(child.key, child.dirty) : this.dirty.remove(child.key));
       var serialized = this.serialized.set(child.key, child.serialized);
       return this.__with({node, value, validation, dirty, serialized});
     }
@@ -285,12 +287,12 @@ class Value {
         }
       }
       value = value.asImmutable();
-      var {node, value} = this.abstractNode.instantiate(value);
+      var {node, value, dirty} = this.abstractNode.instantiate(value, this.node);
       var childrenValidation = areChildrenValid ?
         ValidationResult.success() :
         new ValidationResult(null, children.map(c => c.validation));
       var validation = validate(node, value, childrenValidation);
-      var dirty = this.dirty.merge(children.filter(c => c.dirty.size > 0).map(c => c.dirty));
+      dirty = dirty ? dirty : this.dirty.merge(children.filter(c => c.dirty.size > 0).map(c => c.dirty));
       var serialized = this.serialized.merge(children.map(c => c.serialized));
       return this.__with({node, value, validation, dirty, serialized});
     } else {
@@ -315,7 +317,7 @@ class Value {
     if (value === undefined) {
       value = defaultValue(abstractNode);
     }
-    var {node, value} = abstractNode.instantiate(value);
+    var {node, value} = abstractNode.instantiate(value, undefined);
     var externalValidation = ValidationResult.success();
     var validation = ValidationResult.success();
     var serialized = serialize(node, value);


### PR DESCRIPTION
- pass old node to `Node#instantiate` as second arg
- handle `dirty` return from `Node#instantiate`
- drop validation result when schema node changes to new instance of same class
