### PR TITLE
Solve direct super call in non-constructor method

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -156,7 +156,7 @@ class ScalarNode extends ConcreteNode {
     if (value instanceof Error) {
       return value;
     } else {
-      return super(value, childrenValidation)
+      return super.validate(value, childrenValidation)
     }
   }
 
@@ -305,7 +305,7 @@ class MappingNode extends CompositeNode {
         missingKeysValidation = missingKeysValidation.set(k, VALUE_IS_REQUIRED));
       return ValidationResult.children(childrenValidation.children.merge(missingKeysValidation));
     }
-    return super(value, childrenValidation);
+    return super.validate(value, childrenValidation);
   }
 
   getChildren() {


### PR DESCRIPTION
Super was direct called in validation methods in schema, this was generating transpilations errors when using babel.
This fix makes the babel works fine with react-forms.