### PR TITLE
Get rid of react@15.x warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/prometheusresearch/react-forms/issues"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
Get rid of these annoying warnings:

```
npm WARN react-forms@2.0.0-beta16 requires a peer of react@^0.14.0 but none was installed.
npm WARN react-stylesheet@0.7.1 requires a peer of react@^0.14.0 but none was installed.
```
