### PR TITLE
Patch React 15 warnings

### DIFF
--- a/src/ErrorList.js
+++ b/src/ErrorList.js
@@ -40,8 +40,8 @@ export default class ErrorList extends Component {
   });
 
   render() {
-    let {
-      noLabel, hideNonForced, complete, schemaType, stylesheet,
+    // eslint-disable-next-line no-unused-vars
+    let { noLabel, hideNonForced, complete, schemaType, stylesheet, formValue, select, label,
       ...props
     } = this.props;
     let {Root, Error} = stylesheet || this.constructor.stylesheet;

--- a/src/Fieldset.js
+++ b/src/Fieldset.js
@@ -19,6 +19,7 @@ export default class Fieldset extends Component {
 
   render() {
     let {Root} = this.props.stylesheet || this.constructor.stylesheet;
-    return <Root {...this.props} />;
+    let {stylesheet, formValue, select, selectFormValue, ...props} = this.props
+    return <Root {...props} />;
   }
 }

--- a/src/Fieldset.js
+++ b/src/Fieldset.js
@@ -19,7 +19,8 @@ export default class Fieldset extends Component {
 
   render() {
     let {Root} = this.props.stylesheet || this.constructor.stylesheet;
-    let {stylesheet, formValue, select, selectFormValue, ...props} = this.props
+    // eslint-disable-next-line no-unused-vars
+    let {stylesheet, formValue, select, selectFormValue, ...props} = this.props;
     return <Root {...props} />;
   }
 }

--- a/src/Input.js
+++ b/src/Input.js
@@ -39,6 +39,9 @@ export default class Input extends React.Component {
     if (debounceEnabled) {
       value = this.state.value;
     }
+    if (Component === 'input' && (value === undefined || value === null)) {
+      value = '';
+    }
     return (
       <Component
         {...props}


### PR DESCRIPTION
Fixes this warning (#150) when value for input is `undefined` or `null` by using an empty string for value when required.
```
A component is changing a controlled input of type text to be uncontrolled.
Input elements should not switch from controlled to uncontrolled (or vice versa).
Decide between using a controlled or uncontrolled input element for the
lifetime of the component. More info: https://fb.me/react-controlled-components
```

Fixes this warning by removing known keys from spreaded props.
```
Warning: Unknown props `stylesheet`, `formValue` on <form> tag.
Remove these props from the element. For details, see https://fb.me/react-unknown-prop
```