### PR TITLE
Fix react warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-- stable
+- lts/*
 before_install: npm install -g npm@latest
 after_success: make report-cov-coveralls

--- a/package.json
+++ b/package.json
@@ -58,9 +58,8 @@
     "nyc": "^6.1.1",
     "power-assert": "^1.3.1",
     "prettier": "^1.7.0",
-    "react": "^0.14.0 || ^15.0.0",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^0.14.0 || ^15.0.0",
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0",
     "sinon": "^1.16.1",
     "tape": "^2.13.4",
     "webpack": "^1.12.14"

--- a/src/Component.js
+++ b/src/Component.js
@@ -2,7 +2,8 @@
  * @copyright 2015-present, Prometheus Research, LLC
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import keyPath from './keyPath';
 

--- a/src/ErrorList.js
+++ b/src/ErrorList.js
@@ -2,7 +2,8 @@
  * @copyright 2015-present, Prometheus Research, LLC
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import * as Stylesheet from 'react-stylesheet';
 import some from 'lodash/some';
 

--- a/src/Field.js
+++ b/src/Field.js
@@ -2,10 +2,11 @@
  * @copyright 2015-present, Prometheus Research, LLC
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
 import * as Stylesheet from 'react-stylesheet';
 
 import Component from './Component';
+import PropTypes from 'prop-types';
 import Input from './Input';
 import Label from './Label';
 import ErrorList from './ErrorList';

--- a/src/Fieldset.js
+++ b/src/Fieldset.js
@@ -2,7 +2,8 @@
  * @copyright 2015, Prometheus Research, LLC
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import * as Stylesheet from 'react-stylesheet';
 import Component from './Component';
 

--- a/src/Input.js
+++ b/src/Input.js
@@ -2,7 +2,8 @@
  * @copyright 2015, Prometheus Research, LLC
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import noop from 'lodash/noop';
 

--- a/src/__tests__/Component-test.js
+++ b/src/__tests__/Component-test.js
@@ -3,7 +3,7 @@
  */
 
 import React     from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import Component from '../Component';
 
 const ReactHasContextSupport = !!/^0\.14\.\d/.exec(React.version);

--- a/src/__tests__/ErrorList-test.js
+++ b/src/__tests__/ErrorList-test.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import Error from '../Error';
 import ErrorList from '../ErrorList';
 

--- a/src/__tests__/Fieldset-test.js
+++ b/src/__tests__/Fieldset-test.js
@@ -3,7 +3,7 @@
  */
 
 import React     from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import Fieldset  from '../Fieldset';
 import Component from '../Component';
 

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -2,10 +2,10 @@
  * @copyright 2015 Prometheus Research, LLC
  */
 
-import assert     from 'power-assert';
-import jsdom      from 'jsdom';
-import sinon      from 'sinon';
-import TestUtils  from 'react-addons-test-utils';
+import assert    from 'power-assert';
+import jsdom     from 'jsdom';
+import sinon     from 'sinon';
+import TestUtils from 'react-dom/test-utils';
 
 let document = jsdom.jsdom('<!doctype html><html><body></body></html>');
 let window = document.defaultView;

--- a/src/__tests__/withFormValue-test.js
+++ b/src/__tests__/withFormValue-test.js
@@ -3,7 +3,7 @@
  */
 
 import React          from 'react';
-import TestUtils      from 'react-addons-test-utils';
+import TestUtils      from 'react-dom/test-utils';
 
 import Fieldset       from '../Fieldset';
 import withFormValue  from '../withFormValue';


### PR DESCRIPTION
React 15.5 moved `React.PropTypes` to a separate package and `react-addons-test-utils` to `react-dom`

This fixes the warnings about that.